### PR TITLE
Fix Python compatibility string

### DIFF
--- a/octoprint_title_status/__init__.py
+++ b/octoprint_title_status/__init__.py
@@ -62,11 +62,11 @@ class TitleStatusPlugin(octoprint.plugin.AssetPlugin, octoprint.plugin.EventHand
 		)
 
 __plugin_name__ = "Title Status"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__
 	__plugin_implementation__ = TitleStatusPlugin()
-	__plugin_pythoncompat__ = ">=2.7,<4"
 
 	global __plugin_hooks__
 	__plugin_hooks__ = {


### PR DESCRIPTION
Compatibility flag was in the wrong place, so it is not picked up by OctoPrint. This PR fixes it, making full compatibility to Python 3.

Closes #6 